### PR TITLE
Add support for notification payloads

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net"
+	"net/http"
 	"time"
 )
 
@@ -29,7 +29,7 @@ const (
 
 var (
 	// Errors
-	ErrDataIsEmpty  = errors.New("data is empty")
+	ErrDataIsEmpty  = errors.New("data and notification are empty")
 	ErrToManyRegIDs = errors.New("too many registrations ids")
 )
 
@@ -124,15 +124,32 @@ func (c *Client) SetData(d interface{}) {
 	c.Message.Data = d
 }
 
+// SetNotification Set notification for message
+func (c *Client) SetNotification(n *NotificationPayload) {
+	c.Message.Notification = n
+}
+
 // SetMsgAndTo 'To' this parameter specifies the recipient of a message.
 func (c *Client) PushSingle(to string, d interface{}) {
 	c.SetData(d)
 	c.Message.To = to
 }
 
+// PushSingleNotification send a notification to a single token
+func (c *Client) PushSingleNotification(to string, n *NotificationPayload) {
+	c.SetNotification(n)
+	c.Message.To = to
+}
+
 // SetMsgAndIds Set Message and ids for send
 func (c *Client) PushMultiple(ids []string, d interface{}) {
 	c.SetData(d)
+	c.Message.RegistrationIds = ids
+}
+
+// PushMultipleNotification send a Notification to multiple ids
+func (c *Client) PushMultipleNotification(ids []string, n *NotificationPayload) {
+	c.SetNotification(n)
 	c.Message.RegistrationIds = ids
 }
 
@@ -214,8 +231,8 @@ func (c *Client) Send() (*response, error) {
 
 // validateData return error if data is wrong
 func (c *Client) validateData() error {
-	// Data is empty
-	if c.Message.Data == nil {
+	// Data and Notification is empty
+	if c.Message.Data == nil && c.Message.Notification == nil {
 		return ErrDataIsEmpty
 	}
 

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -54,6 +54,26 @@ func TestClient_PushSingle(t *testing.T) {
 	}
 }
 
+func TestClient_PushSingleNotification(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("key")
+
+	notif := NotificationPayload{
+		Title: "a title",
+		Body:  "a body",
+	}
+	client.PushSingle("token1", notif)
+
+	if client.Message.To == "" {
+		t.Error("To is empty")
+	}
+
+	if len(client.Message.RegistrationIds) != 0 {
+		t.Errorf("expected size 0 got %v", len(client.Message.RegistrationIds))
+	}
+}
+
 func TestClient_PushMultiple(t *testing.T) {
 	t.Parallel()
 
@@ -64,6 +84,27 @@ func TestClient_PushMultiple(t *testing.T) {
 	}
 
 	client.PushMultiple(tokens, data)
+
+	if client.Message.To != "" {
+		t.Error("To is not empty")
+	}
+
+	if len(client.Message.RegistrationIds) != 3 {
+		t.Errorf("expected 3, got %d", len(client.Message.RegistrationIds))
+	}
+}
+
+func TestClient_PushMultipleNotification(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("key")
+	tokens := []string{"token1", "token2", "token3"}
+	notif := NotificationPayload{
+		Title: "a title",
+		Body:  "a body",
+	}
+
+	client.PushMultiple(tokens, notif)
 
 	if client.Message.To != "" {
 		t.Error("To is not empty")


### PR DESCRIPTION
Notifications are currently not possible with the `PushSingle` or `PushMultiple` methods. Instead you must manually set `To` and `Notification` and then throw junk data in `Data` to get this to work. 

Since Data is not required[1] for notifications, I also changed the error conditions for empty Message.Data. 

1. https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-json